### PR TITLE
Initial installation bug

### DIFF
--- a/db/install.xml
+++ b/db/install.xml
@@ -5,6 +5,7 @@
       <FIELDS>
         <FIELD NAME="id" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="true" />
         <FIELD NAME="course" TYPE="int" LENGTH="10" NOTNULL="true" SEQUENCE="false"/>
+        <FIELD NAME="eventbasedsync" TYPE="int" LENGTH="10" NOTNULL="true" default="0" SEQUENCE="false"/>
         <FIELD NAME="pendingsync" TYPE="int" LENGTH="10" NOTNULL="true" default="0" SEQUENCE="false"/>
         <FIELD NAME="lastsync" TYPE="int" LENGTH="10" NOTNULL="false" SEQUENCE="false"/>
         <FIELD NAME="error" TYPE="text" NOTNULL="false" SEQUENCE="false"/>


### PR DESCRIPTION
Due to a column only being added in the upgrades file, a break occurs when using the plugin after a fresh installation. I have updated the installation file to include the column.